### PR TITLE
Avoid counting whitespace twice

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -61,6 +61,8 @@ impl Screen {
                     self.cells[y][x] = Cell { char, style };
                     x += 1;
                 }
+
+                x += word.whitespace_width();
             }
 
             y += 1;
@@ -126,7 +128,6 @@ pub fn to_text(mut s: &str) -> Vec<StyledWord> {
             }
             ' ' => {
                 word.white += 1;
-                word.string.push(' ');
                 new = true;
             }
             c => {


### PR DESCRIPTION
The `Fragment::width` method should give the width of the fragment _without_ the attached whitespace. So we should not push trailing spaces onto the current word.

On the other hand, we need to take the trailing whitespace into account when rendering the `StyledWord`s.